### PR TITLE
Clarify proto details in everloop driver

### DIFF
--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -61,16 +61,18 @@ Each of the following functions receives an integer in the range [0, 255].
 | SetBlue       | Set value of blue component |
 | SeWhite       | Set value of white component |
 
-That is:
+That is, repeat 35 times:
 
     ledValue.setRed(red_value)
     ledValue.setGreen(green_value)
     ledValue.setBlue(blue_value)
     ledValue.setWhite(white_value)
 
+    config.image.led.push(ledValue)
+
 ##### Send configuration
 
-    config.image.led.push(ledValue)
+configSocket.send(config.encode().toBuffer())
 
 #### All steps combined
 

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -105,7 +105,7 @@ The following snippet will make all the greens display the green color.
     config.image = new matrixMalosBuilder.EverloopImage
     for (var j = 0; j < 35; ++j) {
       var ledValue = new matrixMalosBuilder.LedValue
-      ledValue.setRed(0);
+      ledValue.setRed(0)
       ledValue.setGreen(30)
       ledValue.setBlue(0)
       ledValue.setWhite(0)

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -8,36 +8,6 @@ It follows the [MALOS protocol](../README.md#protocol).
 20021
 ```
 
-### Protocol buffers
-
-There is a JavaScript example for the following details so you can skip this section if you're not familiar with protocol buffers and
-if you are impatient and want to see the LEDs working as soon as possible.
-
-The messages used by this driver are defined in [driver.proto](https://github.com/matrix-io/protocol-buffers/blob/master/malos/driver.proto).
-
-```
-message EverloopImage {
-  repeated LedValue led = 1;
-}
-```
-
-
-The message `EverloopImage` needs to have exactly 35 messages of type `LedValue` in the repeated field `led`,
-corresponding to each of the LEDs present in the Creator. The LEDs are counted starting from the left, clock-wise
-as shown in the picture.
-
-![Everloop LEDs](creator-front-everloop-leds.png)
-
-The message LedValue holds the color values for each LED and each value is in the range [0, 255].
-
-```
-message LedValue {
-  uint32 red = 1;
-  uint32 green = 2;
-  uint32 blue = 3;
-  uint32 white = 4;
-}
-```
 
 ### Keep-alives
 
@@ -58,7 +28,7 @@ Some variables used below are defined in the example (for instance matrixMalosBu
 
 In order to set the LEDs of the Creator you need to perform the following steps.
 
-#### Create a configuration that will be sent to the Everloop driver.
+#### Initialize configuration
 
     var config = new matrixMalosBuilder.DriverConfig
 
@@ -112,3 +82,36 @@ The following snippet will make all the greens display the green color.
       config.image.led.push(ledValue)
     }
     configSocket.send(config.encode().toBuffer())
+
+
+
+### Glossary
+
+#### Protocol buffers
+
+In this section we get into the details of the [protocol buffers](https://developers.google.com/protocol-buffers/docs/proto3) used by the
+JavaScript example to communicate with the Everloop driver.
+The messages used by this driver are defined in [driver.proto](https://github.com/matrix-io/protocol-buffers/blob/master/malos/driver.proto).
+
+```
+message EverloopImage {
+  repeated LedValue led = 1;
+}
+```
+
+The message `EverloopImage` needs to have exactly 35 messages of type `LedValue` in the repeated field `led`,
+corresponding to each of the LEDs present in the Creator. The LEDs are counted starting from the left, clock-wise
+as shown in the picture.
+
+![Everloop LEDs](creator-front-everloop-leds.png)
+
+The message LedValue holds the color values for each LED and each value is in the range [0, 255].
+
+```
+message LedValue {
+  uint32 red = 1;
+  uint32 green = 2;
+  uint32 blue = 3;
+  uint32 white = 4;
+}
+```

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -32,11 +32,11 @@ In order to set the LEDs of the Creator you need to perform the following steps.
 
     var config = new matrixMalosBuilder.DriverConfig
 
-#### Create the object that will hold the LED configuration.
+#### Create LED configuration object
 
     config.image = new matrixMalosBuilder.EverloopImage
 
-#### Set the LED state of each LED in the board.
+#### Set LED states
 
 The following steps needs to be repeated 35 times, once per LED.
 
@@ -45,7 +45,7 @@ as shown in the picture.
 
 ![Everloop LEDs](creator-front-everloop-leds.png)
 
-##### Create the object that holds the LED state
+##### Individual LED state
 
 First, create the object.
  
@@ -68,11 +68,11 @@ That is:
     ledValue.setBlue(blue_value)
     ledValue.setWhite(white_value)
 
-##### Send the configuration to the Everloop driver
+##### Send configuration
 
     config.image.led.push(ledValue)
 
-#### All the steps combined
+#### All steps combined
 
 The following snippet will make all the greens display the green color.
 

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -4,10 +4,10 @@ The Everloop driver controls the LED array of the MATRIX Creator.
 It follows the [MALOS protocol](../README.md#protocol).
 
 ### 0MQ Port
+
 ```
 20021
 ```
-
 
 ### Keep-alives
 
@@ -21,7 +21,7 @@ This driver report errors when an invalid configuration is sent.
 
 This driver doesn't send any data to a subscribed program.
 
-### JavaScript example
+### Example usage
 
 This section provides an enhanced description of the relevant parts of the [sample source code](../src/js_test/test_everloop.js).
 Some variables used below are defined in the example (for instance matrixMalosBuilder).

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -10,13 +10,17 @@ It follows the [MALOS protocol](../README.md#protocol).
 
 ### Protocol buffers
 
-The messages are defined in [driver.proto](https://github.com/matrix-io/protocol-buffers/blob/master/malos/driver.proto).
+There is a JavaScript example for the following details so you can skip this section if you're not familiar with protocol buffers and
+if you are impatient and want to see the LEDs working as soon as possible.
+
+The messages used by this driver are defined in [driver.proto](https://github.com/matrix-io/protocol-buffers/blob/master/malos/driver.proto).
 
 ```
 message EverloopImage {
   repeated LedValue led = 1;
 }
 ```
+
 
 The message `EverloopImage` needs to have exactly 35 messages of type `LedValue` in the repeated field `led`,
 corresponding to each of the LEDs present in the Creator. The LEDs are counted starting from the left, clock-wise
@@ -49,87 +53,62 @@ This driver doesn't send any data to a subscribed program.
 
 ### JavaScript example
 
-Enhanced description of the [sample source code](../src/js_test/test_everloop.js).
+This section provides an enhanced description of the relevant parts of the[sample source code](../src/js_test/test_everloop.js).
+Some variables used below are defined in the example (for instance matrixMalosBuilder).
 
+In order to set the LEDs of the Creator you need to perform the following steps.
 
-First, define the address of the MATRIX Creator. In this case we make it be `127.0.0.1`
-because we are connecting from the local host but it needs to be different if we
-connect from another computer. There is also the base port reserved by MALOS for
-the Everloop driver.
+#### Create a configuration that will be sent to the Everloop driver.
 
-```
-var creator_ip = '127.0.0.1'
-var creator_everloop_base_port = 20013 + 8 // base port for Everloop driver.
-```
+    var config = new matrixMalosBuilder.DriverConfig
 
-Load the protocol buffers used in the example.
+#### Create the object that will hold the LED configuration.
 
-```
-var protoBuf = require("protobufjs");
-var protoBuilder = protoBuf.loadProtoFile('../../protocol-buffers/malos/driver.proto')
-var matrixMalosBuilder = protoBuilder.build("matrix_malos")
-```
+    config.image = new matrixMalosBuilder.EverloopImage
 
-Create the configuration 0MQ socket. It will be used to send the configuration of the LEDs to MALOS.
+#### Set the LED state of each LED in the board.
 
-```
-var zmq = require('zmq')
-var configSocket = zmq.socket('push')
-configSocket.connect('tcp://' + creator_ip + ':' + creator_everloop_base_port /* config */)
-```
+The following steps needs to be repeated 35 times, once per LED.
 
-Subscribe to errors. To trigger an error you can send an invalid configuration to the driver.
+##### Create the object that holds the LED state
 
-```
-var errorSocket = zmq.socket('sub')
-errorSocket.connect('tcp://' + creator_ip + ':' + (creator_everloop_base_port + 2))
-errorSocket.subscribe('')
-errorSocket.on('message', function(error_message) {
-  process.stdout.write('Message received: Pressure error: ' + error_message.toString('utf8') + "\n")
-});
-```
+First, create the object.
+ 
+    var ledValue = new matrixMalosBuilder.LedValue
 
-All the drivers are configured using the message `DriverConfig` (see [driver.proto](https://github.com/matrix-io/protocol-buffers/blob/master/malos/driver.proto)).
-This is what the message looks like if we omit the fields that are not used in this example.
+Now fill out the state of a given led by calling the following functions on ledValue.
+Each of the following functions receives an integer in the range [0, 255].
 
-    message DriverConfig {
-      EverloopImage image = 3;
-    }
+| Function      |   Objective   |
+| ------------- |:-------------:|
+| setRed        | Set value of red component  |
+| setGreen      | Set value of green component |
+| SetBlue       | Set value of green component |
+| SeWhite       | Set value of white component |
 
-In the next snippet we instantiate a message of type `DriverConfig` and
-the field `image` is set to an instance of a message of type `EverloopImage`.
-Then exactly 35 instances of the message `LedValue` are added to the repeated `led` field.
-At the end a serialized configuration is sent to the Everloop driver via 0MQ.
+That is:
 
-```
-var max_intensity = 50
-var intensity_value = max_intensity
+    ledValue.setRed(red_value)
+    ledValue.setGreen(green_value)
+    ledValue.setBlue(blue_value)
+    ledValue.setWhite(white_value)
 
-function setEverloop() {
+##### Send the configuration to the Everloop driver
+
+    config.image.led.push(ledValue)
+
+#### All the steps combined
+
+The following snippet will make all the greens display the green color.
+
     var config = new matrixMalosBuilder.DriverConfig
     config.image = new matrixMalosBuilder.EverloopImage
     for (var j = 0; j < 35; ++j) {
       var ledValue = new matrixMalosBuilder.LedValue;
       ledValue.setRed(0);
-      ledValue.setGreen(intensity_value);
+      ledValue.setGreen(30);
       ledValue.setBlue(0);
       ledValue.setWhite(0);
       config.image.led.push(ledValue)
     }
     configSocket.send(config.encode().toBuffer());
-}
-
-setEverloop(intensity_value)
-```
-
-This is the code that makes green LED go from 50 to 0 in an endless loop.
-The state of the LEDs is updated every 10 milliseconds by calling the setEverloop function.
-
-```
-setInterval(function() {
-  intensity_value -= 1
-  if (intensity_value < 0)
-    intensity_value = max_intensity
-  setEverloop()
-}, 10);
-```

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -40,6 +40,11 @@ In order to set the LEDs of the Creator you need to perform the following steps.
 
 The following steps needs to be repeated 35 times, once per LED.
 
+The LEDs are counted starting from the left, clock-wise
+as shown in the picture.
+
+![Everloop LEDs](creator-front-everloop-leds.png)
+
 ##### Create the object that holds the LED state
 
 First, create the object.
@@ -100,10 +105,7 @@ message EverloopImage {
 ```
 
 The message `EverloopImage` needs to have exactly 35 messages of type `LedValue` in the repeated field `led`,
-corresponding to each of the LEDs present in the Creator. The LEDs are counted starting from the left, clock-wise
-as shown in the picture.
-
-![Everloop LEDs](creator-front-everloop-leds.png)
+corresponding to each of the LEDs present in the Creator.
 
 The message LedValue holds the color values for each LED and each value is in the range [0, 255].
 

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -53,7 +53,7 @@ This driver doesn't send any data to a subscribed program.
 
 ### JavaScript example
 
-This section provides an enhanced description of the relevant parts of the[sample source code](../src/js_test/test_everloop.js).
+This section provides an enhanced description of the relevant parts of the [sample source code](../src/js_test/test_everloop.js).
 Some variables used below are defined in the example (for instance matrixMalosBuilder).
 
 In order to set the LEDs of the Creator you need to perform the following steps.
@@ -83,7 +83,7 @@ Each of the following functions receives an integer in the range [0, 255].
 | ------------- |:-------------:|
 | setRed        | Set value of red component  |
 | setGreen      | Set value of green component |
-| SetBlue       | Set value of green component |
+| SetBlue       | Set value of blue component |
 | SeWhite       | Set value of white component |
 
 That is:

--- a/docs/everloop.md
+++ b/docs/everloop.md
@@ -104,11 +104,11 @@ The following snippet will make all the greens display the green color.
     var config = new matrixMalosBuilder.DriverConfig
     config.image = new matrixMalosBuilder.EverloopImage
     for (var j = 0; j < 35; ++j) {
-      var ledValue = new matrixMalosBuilder.LedValue;
+      var ledValue = new matrixMalosBuilder.LedValue
       ledValue.setRed(0);
-      ledValue.setGreen(30);
-      ledValue.setBlue(0);
-      ledValue.setWhite(0);
+      ledValue.setGreen(30)
+      ledValue.setBlue(0)
+      ledValue.setWhite(0)
       config.image.led.push(ledValue)
     }
-    configSocket.send(config.encode().toBuffer());
+    configSocket.send(config.encode().toBuffer())


### PR DESCRIPTION
Once we agree on a format for driver documentation we can go and modify other drivers. This should be an example.

You can preview check the resulting changes [here](https://github.com/matrix-io/matrix-creator-malos/blob/nc/clarify_proto_details_in_everloop_driver/docs/everloop.md). 
