### PR TITLE
Improving temp calibration

### DIFF
--- a/src/driver_humidity.cpp
+++ b/src/driver_humidity.cpp
@@ -77,9 +77,6 @@ bool HumidityDriver::SendUpdate() {
 bool HumidityDriver::ProcessConfig(const DriverConfig &config) {
   HumidityParams humidity_params(config.humidity());
 
-  // Check if calibration is needed
-  if (!humidity_params.do_calibration()) return false;
-
   // Resetting the calibrated flag
   calibrated_ = false;
 

--- a/src/js_test/test_humidity.js
+++ b/src/js_test/test_humidity.js
@@ -47,7 +47,6 @@ driverConfigProto.timeout_after_last_ping = 6.0
 var hum_params_msg = new matrixMalosBuilder.HumidityParams
 // Real current temperature [Celsius] for calibration 
 hum_params_msg.current_temperature = 23
-hum_params_msg.do_calibration = true
 driverConfigProto.set_humidity(hum_params_msg)
 // Send driver configuration.
 configSocket.send(driverConfigProto.encode().toBuffer())


### PR DESCRIPTION
Removing the do_calibration in the humidity calibration message. Its not required. Now you just send the current_temperature and the calibrated_ value changes. 