### PR TITLE
Py examples compatibility with 2 & 3 and CREATOR_IP env var

### DIFF
--- a/src/python_test/test_driver_info.py
+++ b/src/python_test/test_driver_info.py
@@ -14,12 +14,13 @@
 # before run this example please execute:
 # pip install pyzmq protobuf matrix_io-proto
 
+import os
 import zmq
 import time
 from matrix_io.proto.malos.v1 import driver_pb2 as driver_proto
 
 # or local ip of MATRIX creator
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 creator_base_port = 20012
 
 # grab zmq context

--- a/src/python_test/test_everloop.py
+++ b/src/python_test/test_everloop.py
@@ -18,6 +18,7 @@
 # there seems to be a delay when running this at high framerates
 # look into using queues to pass messages between threads
 
+import os
 import zmq
 import time
 from matrix_io.proto.malos.v1 import driver_pb2
@@ -29,7 +30,7 @@ from zmq.eventloop import ioloop
 from utils import register_error_callback
 
 # or local ip of MATRIX creator
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 
 # port for everloop driver
 creator_everloop_base_port = 20013 + 8

--- a/src/python_test/test_gpio.py
+++ b/src/python_test/test_gpio.py
@@ -14,13 +14,14 @@
 # before run this example please execute:
 # pip install pyzmq protobuf matrix_io-proto
 
+import os
 import zmq
 import time
 from matrix_io.proto.malos.v1 import driver_pb2
 from matrix_io.proto.malos.v1 import io_pb2
 
 # or local ip of MATRIX creator
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 creator_gpio_base_port = 20013 + 36
 
 # Grab a zmq context

--- a/src/python_test/test_gpio_read_write.py
+++ b/src/python_test/test_gpio_read_write.py
@@ -14,6 +14,7 @@
 # before run this example please execute:
 # pip install pyzmq protobuf tornado matrix_io-proto
 
+import os
 import zmq
 import time
 from matrix_io.proto.malos.v1 import driver_pb2
@@ -24,7 +25,7 @@ from zmq.eventloop import ioloop, zmqstream
 
 from utils import driver_keep_alive, register_data_callback, register_error_callback
 
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 creator_gpio_base_port = 20013 + 36
 
 

--- a/src/python_test/test_gpio_read_write.py
+++ b/src/python_test/test_gpio_read_write.py
@@ -121,4 +121,4 @@ if __name__ == "__main__":
     Process(target=driver_keep_alive, args=(creator_ip, creator_gpio_base_port, 1)).start()
 
     # Register the callback to send data from the read pin
-    Process(target=register_data_callback, args=(gpio_callback, creator_ip, creator_gpio_base_port))
+    Process(target=register_data_callback, args=(gpio_callback, creator_ip, creator_gpio_base_port)).start()

--- a/src/python_test/test_humidity.py
+++ b/src/python_test/test_humidity.py
@@ -4,6 +4,7 @@
 #
 # (see README file for more details)
 
+import os
 import zmq
 import time
 from matrix_io.proto.malos.v1 import driver_pb2
@@ -15,7 +16,8 @@ from zmq.eventloop import ioloop
 from utils import driver_keep_alive, register_data_callback, register_error_callback
 
 # or local ip of MATRIX creator
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
+
 humidity_port = 20013 + 4
 
 

--- a/src/python_test/test_pressure.py
+++ b/src/python_test/test_pressure.py
@@ -4,6 +4,7 @@
 #
 # (see README file for more details)
 
+import os
 from matrix_io.proto.malos.v1 import sense_pb2
 
 from multiprocessing import Process
@@ -12,7 +13,7 @@ from zmq.eventloop import ioloop
 from utils import driver_keep_alive, register_data_callback, register_error_callback
 
 # or local ip of MATRIX creator
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 pressure_port = 20013 + 12
 
 

--- a/src/python_test/test_servo.py
+++ b/src/python_test/test_servo.py
@@ -17,13 +17,14 @@
 # NOTE:
 # THIS NEEDS TO BE TESTED! I DON'T HAVE A SERVO TO TEST ON!
 
+import os
 import zmq
 from matrix_io.proto.malos.v1 import driver_pb2
 
 
 def send_servo_command(pin=4):
     # or local ip of MATRIX creator
-    creator_ip = '127.0.0.1'
+    creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
     creator_servo_base_port = 20013 + 32
 
     # Set a base count of 0

--- a/src/python_test/test_set_everloop_color.py
+++ b/src/python_test/test_set_everloop_color.py
@@ -14,6 +14,9 @@
 # before run this example please execute:
 # pip install pyzmq protobuf matrix_io-proto
 
+import os
+import random
+import time
 import zmq
 from matrix_io.proto.malos.v1 import driver_pb2
 from matrix_io.proto.malos.v1 import io_pb2
@@ -23,7 +26,7 @@ def set_everloop_color(red=0, green=0, blue=0, white=0):
     """Submit a R,G,B,W value between 0-255"""
 
     # or local ip of MATRIX creator
-    creator_ip = '127.0.0.1'
+    creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 
     # port for everloop driver
     creator_everloop_base_port = 20013 + 8
@@ -58,5 +61,9 @@ def set_everloop_color(red=0, green=0, blue=0, white=0):
     # to the config socket
     config_socket.send(config.SerializeToString())
 
+
 if __name__ == '__main__':
-    set_everloop_color(0, 0, 255, 0)
+    while True:
+        # Set random values for R, G and B
+        set_everloop_color(*random.sample(range(0, 255), 3))
+        time.sleep(1)

--- a/src/python_test/test_uv.py
+++ b/src/python_test/test_uv.py
@@ -4,6 +4,7 @@
 #
 # (see README file for more details)
 
+import os
 import zmq
 import time
 from matrix_io.proto.malos.v1 import sense_pb2
@@ -14,7 +15,7 @@ from zmq.eventloop import ioloop
 from utils import driver_keep_alive, register_data_callback, register_error_callback
 
 # local ip of MATRIX creator
-creator_ip = '127.0.0.1'
+creator_ip = os.environ.get('CREATOR_IP', '127.0.0.1')
 uv_port = 20013 + 16
 
 

--- a/src/python_test/utils.py
+++ b/src/python_test/utils.py
@@ -26,7 +26,7 @@ def register_data_callback(callback, creator_ip, sensor_port):
     socket.connect('tcp://{0}:{1}'.format(creator_ip, data_port))
 
     # Set socket options to subscribe and send off en empty string to let it know we're ready
-    socket.setsockopt_string(zmq.SUBSCRIBE, '')
+    socket.setsockopt(zmq.SUBSCRIBE, b'')
 
     # Create the stream to listen to
     stream = zmqstream.ZMQStream(socket)
@@ -56,7 +56,7 @@ def register_error_callback(callback, creator_ip, sensor_port):
     socket.connect('tcp://{0}:{1}'.format(creator_ip, error_port))
 
     # Set socket options to subscribe and send off en empty string to let it know we're ready
-    socket.setsockopt_string(zmq.SUBSCRIBE, '')
+    socket.setsockopt(zmq.SUBSCRIBE, b'')
 
     # Create a stream to listen to
     stream = zmqstream.ZMQStream(socket)


### PR DESCRIPTION
- Small tweak to make `socket.setsockopt` compatible with python 2 and 3. 
- Adds `CREATOR_IP` env var lookup to sample scripts so it's easy to use the samples outside of the Pi.  